### PR TITLE
move botocore bounds into a single jinja variable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@
 {% set botocore_patch = vpatch | int + 0 %}
 {% set botocore_min = botocore_major ~ '.' ~ botocore_minor ~ '.' ~ botocore_patch %}
 {% set botocore_max = botocore_major ~ '.' ~ (botocore_minor + 1) ~ '.0' %}
+{% set botocore_bounds = '>=' ~ botocore_min ~ ',<' ~ botocore_max %}
 
 package:
   name: boto3
@@ -18,7 +19,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
@@ -28,7 +29,7 @@ requirements:
     - pip
   run:
     - python
-    - botocore >={{ botocore_min }},<{{ botocore_max }}
+    - botocore {{ botocore_bounds }}
     - jmespath >=0.7.1,<1.0.0
     - s3transfer >=0.3.0,<0.4.0
 


### PR DESCRIPTION
I think the `<{{` is confusing the latest autotick code

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
